### PR TITLE
uiGradients v0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uigradients",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "a uigradients.com generator for styled-components.",
   "main": "dist/uigradients.js",
   "scripts": {
@@ -20,7 +20,7 @@
     "url": "git+https://github.com/garetmckinley/uigradients.git"
   },
   "author": "Garet McKinley",
-  "license": "ISC",
+  "license": "MIT",
   "devDependencies": {
     "babel-cli": "^6.18.0",
     "babel-core": "^6.18.2",

--- a/src/generator.js
+++ b/src/generator.js
@@ -18,6 +18,14 @@ background-image: -webkit-linear-gradient(
   ${angle}deg,
   ${gradients[gradient][0]},
   ${gradients[gradient][1]});
+background-image: -moz-linear-gradient(
+  ${angle}deg,
+  ${gradients[gradient][0]},,
+  ${gradients[gradient][1]});
+background-image: -o-linear-gradient(
+  ${angle}deg,
+  ${gradients[gradient][0]},,
+  ${gradients[gradient][1]});
 background-image: linear-gradient(
   ${angle}deg,
   ${gradients[gradient][0]},


### PR DESCRIPTION
- Added browser specific css rules for Firefox and Opera in the `generator`.
- Fixed license in `package.json`