### PR TITLE
Add link to list of gradient presets in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ const Pre = styled.pre`
 `;
 ```
 
+> A complete list of the gradient presets can be found [here](https://github.com/JSBros/uigradients/blob/master/src/gradients.js).
+Test out the presets, or create your own! But be sure to 
+[**PR it**](https://github.com/JSBros/uigradients/compare)so everyone else can 
+benefit from your ascetic awesomeness! 
 #### Or, you can override the built in Gradient component
 
 ``` jsx

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ class App extends Component {
     );
 }
 ```
+> ###### `cherry` is only one of the many presets provided by [_`uigradients`_](https://JSBros/uigradients)
+> A complete list of the gradient presets can be found [here](https://github.com/JSBros/uigradients/blob/master/src/gradients.js).
+> Test out these presets, or create your own! But be sure to 
+[**PR your creation**](https://github.com/JSBros/uigradients/compare) so the 
+rest of the community can benefit from your ascetic awesomeness! 
+
 
 ### Gradient Generator
 
@@ -71,11 +77,8 @@ const Pre = styled.pre`
 `;
 ```
 
-> A complete list of the gradient presets can be found [here](https://github.com/JSBros/uigradients/blob/master/src/gradients.js).
-Test out the presets, or create your own! But be sure to 
-[**PR it**](https://github.com/JSBros/uigradients/compare)so everyone else can 
-benefit from your ascetic awesomeness! 
-#### Or, you can override the built in Gradient component
+
+#### Or, you can override other properties on the Gradient component
 
 ``` jsx
 import { Gradient } from 'uigradients';


### PR DESCRIPTION
I happened upon this repo a few minutes ago, and thought I'd make this quick edit.

------

The [`README.md`](https://github.com/JSBros/uigradients/blob/e49d0162d5078656eff39cb263a59aa53a114dac/README.md) has code samples which use presets referenced to by a string name, such as `electric_violet`. However, it is not immediately apparent what presets are available, nor what they mean. This PR adds a simple link in `README.md` which fixes that, and also encourages package consumers to contribute with a link to the PR page of the GitHub repo.